### PR TITLE
If pdf, outputs link to pdf below the embed

### DIFF
--- a/embed-pdf-viewer.php
+++ b/embed-pdf-viewer.php
@@ -65,7 +65,7 @@ class Embed_PDF_Viewer {
 		if ( 'application/pdf' === $attachment->post_mime_type ) {
 			$out .= '<iframe src="https://docs.google.com/gview?url=' . urlencode( $attachment->guid ) . '&embedded=true" style="width:100%; height:500px;" frameborder="0"></iframe>';
 		}
-
+		$html = '<a href="' . $attachment->guid . '" rel="attachment" >' . $attachment->post_title . '</a>';
 		return $out . $html . "\n\n";
 	}
 


### PR DESCRIPTION
replaces default output of $html (the post permalink) with a direct link to the pdf